### PR TITLE
refactor: rename mata to mataroa-cli

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,1 @@
-mata
+mataroa-cli

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# mata
+# mataroa-cli
 
 [mata](https://github.com/mataroa-blog/mataroa-cli) is CLI tool for [mataroa.blog](https://mataroa.blog).
 
 ## Usage
 
-Run `mata init` to generate the configuration file.
+Run `mataroa init` to generate the configuration file.
 
 ## Building
 

--- a/commands.go
+++ b/commands.go
@@ -13,8 +13,8 @@ import (
 
 func CommandsRoot() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:               "mata",
-		Short:             "mata is a CLI tool for mataroa.blog",
+		Use:               "mataroa-cli",
+		Short:             "mataroa-cli is a CLI tool for mataroa.blog",
 		CompletionOptions: cobra.CompletionOptions{HiddenDefaultCmd: true},
 		DisableAutoGenTag: true,
 	}
@@ -31,11 +31,11 @@ func CommandInit() *cobra.Command {
 
 		filePath, err := xdg.ConfigFile(ConfigurationFilePath)
 		if err != nil {
-			log.Fatalf("error initializing mata: %s", err)
+			log.Fatalf("error initializing mataroa-cli: %s", err)
 		}
 
 		if _, err := os.Stat(filePath); err == nil {
-			log.Fatalf("error initializing mata: config.json already exists")
+			log.Fatalf("error initializing mataroa-cli: config.json already exists")
 		} else if errors.Is(err, os.ErrNotExist) {
 
 			body, err := json.MarshalIndent(Config{
@@ -43,22 +43,22 @@ func CommandInit() *cobra.Command {
 				Token:  "your-api-key-here",
 			}, "", "  ")
 			if err != nil {
-				log.Fatalf("error initializing mata: couldn't marshal json file: %s", err)
+				log.Fatalf("error initializing mataroa-cli: couldn't marshal json file: %s", err)
 			}
 
 			err = os.WriteFile(filePath, body, os.FileMode((0o600)))
 			if err != nil {
-				log.Fatalf("error initializing mata: %s", err)
+				log.Fatalf("error initializing mataroa-cli: %s", err)
 			}
 
-			fmt.Printf("mata initialized successfully: '%s' file created\n", filePath)
+			fmt.Printf("mataroa-cli initialized successfully: '%s' file created\n", filePath)
 		}
 	}
 
 	cmd := &cobra.Command{
 		Use:     "init",
 		Aliases: []string{"i"},
-		Short:   "Initialize mata",
+		Short:   "Initialize mataroa-cli",
 		Run:     run,
 	}
 

--- a/config.go
+++ b/config.go
@@ -9,7 +9,7 @@ import (
 )
 
 const (
-	ConfigurationFilePath = "mata/config.json"
+	ConfigurationFilePath = "mataroa-cli/config.json"
 	EnvVariableApiUrl     = "MATAROA_API_URL"
 	EnvVariableToken      = "MATAROA_TOKEN"
 )


### PR DESCRIPTION
This project used to be called mata. There are some leftover references of that name, which I thought to change. Unless we want to maintain some because of backwards compatbility — is that the case, or should we keep the `mata` name for the binary in any case? I find it slightly confusing but maybe it's not necessarily.